### PR TITLE
Fix: Return user-friendly validation errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,19 @@ import { Elysia } from 'elysia';
 import { swagger } from '@elysiajs/swagger';
 import { userRoutes } from './routes/user-route';
 
+const toFieldLabel = (path: string) => {
+  const field = path.replace(/^\//, '');
+  if (!field) return 'Field';
+  return field.charAt(0).toUpperCase() + field.slice(1);
+};
+
+const toUserMessage = (path: string, summary?: string) => {
+  const label = toFieldLabel(path);
+  if (summary?.includes('email')) return `${label} must be a valid email address`;
+  if (summary?.includes('greater or equal to 1')) return `${label} is required`;
+  return `${label} is invalid`;
+};
+
 export const app = new Elysia()
   .use(swagger({
     documentation: {
@@ -24,6 +37,27 @@ export const app = new Elysia()
       }
     }
   }))
+  .onError(({ code, error, set }) => {
+    if (code === 'VALIDATION') {
+      const errors = ((error as any)?.all ?? []) as Array<{ path?: string; summary?: string }>;
+      const fieldErrors: Record<string, string> = {};
+
+      for (const item of errors) {
+        const path = item.path ?? '';
+        if (!path) continue;
+        const field = path.replace(/^\//, '');
+        if (!fieldErrors[field]) {
+          fieldErrors[field] = toUserMessage(path, item.summary);
+        }
+      }
+
+      set.status = 400;
+      return {
+        error: 'Validation failed',
+        fields: fieldErrors
+      };
+    }
+  })
   .get('/', () => 'Hello, simple-auth-ai is running!')
   .use(userRoutes);
 

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -57,7 +57,7 @@ describe('User Authentication', () => {
         })
       );
 
-      expect(response.status).toBe(422);
+      expect(response.status).toBe(400);
     });
 
     it('rejects registration with an invalid email format', async () => {
@@ -73,7 +73,7 @@ describe('User Authentication', () => {
         })
       );
 
-      expect(response.status).toBe(422);
+      expect(response.status).toBe(400);
     });
 
     it('rejects registration with empty fields', async () => {
@@ -89,7 +89,7 @@ describe('User Authentication', () => {
         })
       );
 
-      expect(response.status).toBe(422);
+      expect(response.status).toBe(400);
     });
   });
 
@@ -141,7 +141,7 @@ describe('User Authentication', () => {
         })
       );
 
-      expect(response.status).toBe(422);
+      expect(response.status).toBe(400);
     });
   });
 

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -74,6 +74,9 @@ describe('User Authentication', () => {
       );
 
       expect(response.status).toBe(400);
+      const result = await response.json() as any;
+      expect(result.error).toBe('Validation failed');
+      expect(result.fields.email).toBe('Email must be a valid email address');
     });
 
     it('rejects registration with empty fields', async () => {
@@ -90,6 +93,11 @@ describe('User Authentication', () => {
       );
 
       expect(response.status).toBe(400);
+      const result = await response.json() as any;
+      expect(result.error).toBe('Validation failed');
+      expect(result.fields.name).toBe('Name is required');
+      expect(result.fields.email).toBe('Email is required');
+      expect(result.fields.password).toBe('Password is required');
     });
   });
 
@@ -142,6 +150,9 @@ describe('User Authentication', () => {
       );
 
       expect(response.status).toBe(400);
+      const result = await response.json() as any;
+      expect(result.error).toBe('Validation failed');
+      expect(result.fields.email).toBe('Email must be a valid email address');
     });
   });
 


### PR DESCRIPTION
## Summary
- Convert raw Elysia validation failures into concise field-level messages for easier client handling.
- Return `400` with `{ error, fields }` on validation failures (required/invalid email messaging).
- Update authentication tests to match the new validation status code behavior.

## Test plan
- [x] Run `npm test`
- [x] Confirm all tests pass (11/11)
- [x] Manually verify empty registration fields return friendly `fields` errors

Made with [Cursor](https://cursor.com)